### PR TITLE
Add fire charge to lighter, change snow to snow_layer in snowman-trail

### DIFF
--- a/1.12.2/lang/presets/minecraft/en_US.conf
+++ b/1.12.2/lang/presets/minecraft/en_US.conf
@@ -31,7 +31,7 @@ flag-descriptions {
     ice-melt="Controls whether ice can melt."
     lava-flow="Controls whether lava can flow."
     leaf-decay="Controls whether leaves can decay."
-    lighter="Controls whether a player can use flint and steel."
+    lighter="Controls whether a player can use flint and steel and fire charges."
     lightning-entity-damage="Controls whether lightning can cause harm."
     monster-animal-damage="Controls whether monsters can deal damage to animals."
     monster-player-damage="Controls whether monsters can deal damage to players."

--- a/1.12.2/presets/minecraft.conf
+++ b/1.12.2/presets/minecraft.conf
@@ -633,7 +633,8 @@ minecraft {
                     default-value=false
                     enabled=true
                     permissions=[
-                        "flag=interact-item-secondary, target=minecraft:flint_and_steel, source=minecraft:player"
+                        "flag=interact-item-secondary, target=minecraft:flint_and_steel, source=minecraft:player",
+                        "flag=interact-item-secondary, target=minecraft:fire_charge, source=minecraft:player"
                     ]
                 }
                 mushroom-growth {
@@ -727,7 +728,7 @@ minecraft {
                     default-value=true
                     enabled=true
                     permissions=[
-                        "flag=block-place, target=minecraft:snow, source=minecraft:snowman"
+                        "flag=block-place, target=minecraft:snow_layer, source=minecraft:snowman"
                     ]
                 }
                 soil-dry {

--- a/1.12.2/presets/minecraft.conf
+++ b/1.12.2/presets/minecraft.conf
@@ -788,5 +788,5 @@ minecraft {
             enabled=true
         }
     }
-    version="1.0"
+    version="1.1"
 }

--- a/1.16.5/lang/presets/minecraft/en_US.conf
+++ b/1.16.5/lang/presets/minecraft/en_US.conf
@@ -32,7 +32,7 @@ flag-descriptions {
     ice-melt="Controls whether ice can melt."
     lava-flow="Controls whether lava can flow."
     leaf-decay="Controls whether leaves can decay."
-    lighter="Controls whether a player can use flint and steel."
+    lighter="Controls whether a player can use flint and steel and fire charges."
     lightning-entity-damage="Controls whether lightning can cause harm."
     monster-animal-damage="Controls whether monsters can deal damage to animals."
     monster-player-damage="Controls whether monsters can deal damage to players."

--- a/1.16.5/presets/minecraft.conf
+++ b/1.16.5/presets/minecraft.conf
@@ -663,7 +663,8 @@ minecraft {
                     default-value=false
                     enabled=true
                     permissions=[
-                        "flag=interact-item-secondary, target=minecraft:flint_and_steel, source=minecraft:player"
+                        "flag=interact-item-secondary, target=minecraft:flint_and_steel, source=minecraft:player",
+                        "flag=interact-item-secondary, target=minecraft:fire_charge, source=minecraft:player"
                     ]
                 }
                 mushroom-growth {
@@ -757,7 +758,7 @@ minecraft {
                     default-value=true
                     enabled=true
                     permissions=[
-                        "flag=block-place, source=minecraft:snow_golem, target=minecraft:snow"
+                        "flag=block-place, source=minecraft:snow_golem, target=minecraft:snow_layer"
                     ]
                 }
                 soil-dry {
@@ -817,5 +818,5 @@ minecraft {
             enabled=true
         }
     }
-    version="1.0"
+    version="1.1"
 }

--- a/1.16.5/presets/minecraft.conf
+++ b/1.16.5/presets/minecraft.conf
@@ -758,7 +758,7 @@ minecraft {
                     default-value=true
                     enabled=true
                     permissions=[
-                        "flag=block-place, source=minecraft:snow_golem, target=minecraft:snow_layer"
+                        "flag=block-place, source=minecraft:snow_golem, target=minecraft:snow"
                     ]
                 }
                 soil-dry {


### PR DESCRIPTION
<!-- Before creating a pull request to submit a new or modified definition or language file, be certain you have tested your file(s) in game and that they work correctly! -->

<!-- All definitions must use the namespace for the mod they are for, and only for a single mod. eg minecraft.conf is for vanilla minecraft. pixelmon.conf is for pixelmon. Verify a mods namespace with it's in-game items and blocks etc -->

<!-- All definitions submitted must follow the same basic layout of GriefDefender's minecraft.conf with USER and ADMIN groups only -->
<!-- Custom grouping can be done by server owners in the manner they choose, and it is easier if everyone is provided with a standard layout to start with -->

<!-- Increment the version string in your definitions file when submitting a change -->
<!-- Version strings are only to be Major.Minor, increment Major only for major changes made to definitions, additions and corrections are minor changes -->

<!-- No comments are to be present in definitions, only definitions and version string -->
Should `block-place target=minecraft:fire` be added to the lighter preset too?